### PR TITLE
[Composer] Added conflict with Symfony 5.2.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,6 +61,9 @@
         "sensio/framework-extra-bundle": "^5.6.1",
         "twig/extra-bundle": "^3.1.1"
     },
+    "conflict": {
+        "symfony/framework-bundle": "5.2.6"
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "3.3.x-dev"


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | n/a
| **Type**                                   | not sure
| **Target Ibexa version** | master (3.3 edition)
| **BC breaks**                          | no
| **Doc needed**                       | no

Symfony 5.2.6 has been released yesterday and it contains a regression:
https://github.com/symfony/symfony/issues/40618

It has been detected by our tests as well:
https://travis-ci.com/github/ezsystems/ezplatform/jobs/494701655
(screenshot: https://res.cloudinary.com/ezplatformtravis/image/upload/v1617084143/screenshots/6062beef4f6f1703756003-vendor_ezsystems_ezplatform-admin-ui_features_personas_subtreeeditor_feature_41_x3qfme.png)

If you want to reproduce it locally you can set up a project (Ibexa OSS/DXP 3.3.x) and configure it to use Symfony Proxy according to https://doc.ibexa.co/en/latest/guide/http_cache/#symfony-reverse-proxy - the same exception is shown.

The issue should be fixed in https://github.com/symfony/symfony/pull/40619 , but it has not been released yet.

Lower versions of our product are not affected, as we limit Symfony version there (https://github.com/ezsystems/ezplatform/blob/3.2/composer.json#L143)

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Checked that target branch is set correctly.
- [x] Asked for a review (ping `@ibexa/engineering`).
