### PR TITLE
IBX-460: Locked doctrine/doctrine-bundle to 2.3.x to avoid issues

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,8 @@
         "php-http/guzzle6-adapter": "^2.0.1",
         "platformsh/symfonyflex-bridge": "^2.4",
         "sensio/framework-extra-bundle": "^5.6.1",
-        "twig/extra-bundle": "^3.1.1"
+        "twig/extra-bundle": "^3.1.1",
+        "doctrine/doctrine-bundle": "~2.3.2"
     },
     "conflict": {
         "symfony/framework-bundle": "5.2.6"


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-460](https://issues.ibexa.co/browse/IBX-460)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3` 
| **BC breaks**                          | no
| **Doc needed**                       | no

`doctrine/doctrine-bundle` 2.4.0 introduced breaking change affecting our installations. Hopefully they will fix it themselves as they received backlash from the community: https://github.com/doctrine/DoctrineBundle/issues/1362
For the time being, in order to unblock coming 3.3.x release we need to lock doctrine bundle to 2.3.x.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Checked that target branch is set correctly.
- [x] Asked for a review (ping `@ibexa/engineering`).
