### PR TITLE
[Composer] Added conflict with symfony/dependency-injection v3.5.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,8 @@
         "doctrine/doctrine-bundle": "^2.4.2"
     },
     "conflict": {
-        "lexik/jwt-authentication-bundle": "2.12.0"
+        "lexik/jwt-authentication-bundle": "2.12.0",
+        "symfony/dependency-injection": "5.3.7"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
Our product (v3.3.x-dev and 4.0.x-dev) fails to install with:
```
!!  In CheckCircularReferencesPass.php line 67:
!!                                                                                 
!!    Circular reference detected for service "Ibexa\Platform\OAuth2Client\Reposi  
!!    tory\User\PasswordHashService", path: "Ibexa\Platform\OAuth2Client\Reposito  
!!    ry\User\PasswordHashService -> Ibexa\Platform\OAuth2Client\Repository\User\  
!!    PasswordHashService". 
```

Which seems to come from the latest Symfony release: https://github.com/symfony/symfony/releases/tag/v5.3.7

and has been reported to the issue tracker: https://github.com/symfony/symfony/issues/42791

I've decided to add a conflict for a single version (no `^`, `~`) because I hope that it will be fixed in 5.3.8 - if not I will change the conflict to a broader one. 




