### PR TITLE
IBX-1466: [Composer] Dropped ezplatform-core requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
         "ibexa/standard-design": "^4.0.x-dev",
         "ibexa/user": "^4.0.x-dev",
         "ibexa/compatibility-layer": "^4.0.x-dev",
-        "ezsystems/ezplatform-core": "^4.0.x-dev",
         "symfony/asset": "^5.3.0",
         "symfony/cache": "^5.3.0",
         "symfony/console": "^5.3.0",


### PR DESCRIPTION
:warning: This PR targets `rebranding` branch.

| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1466](https://issues.ibexa.co/browse/IBX-1466)
| **Requires**                            | ibexa/core#18 and ibexa/compatibility-layer#1
| **Type**                                   | feature
| **Target** | **`dev-rebranding`** for Ibexa `v4.0`
| **BC breaks**                          | no

This PR drops requirement on `ezsystems/ezplatform-core` as parts of it have been scattered through the other packages via:
- [x] ibexa/core#18,
- [x] ibexa/compatibility-layer#1,
- [x] ibexa/admin-ui/pull/54.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Checked that target branch is set correctly.
- [x] Asked for a review (ping `@ibexa/engineering`).
