### PR TITLE
[CI] Removed scheduled runs

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -1,12 +1,9 @@
 name: Browser tests
 on:
-    schedule:
-        # Run tests every night
-        - cron: "0 0 * * *"
     workflow_dispatch: ~
     push:
         branches:
-            - main
+            - master
             - "[0-9]+.[0-9]+"
     pull_request: ~
 


### PR DESCRIPTION
Follow-up to https://github.com/ibexa/oss/pull/22

The `schedule` event type works only for the default branch (https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#scheduled-events , we will need to find a solution for other branches (3.3) as well.

I will create a solution using `workflow_dispatch` soon, for now I'm clearing the not needed config.

I've also renamed the workflow file - without `scheduled` browser tests seems more fitting.