### PR TITLE
[CI] Added nightly browser tests

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,32 @@
+name: Nightly browser tests
+on:
+    schedule:
+        # Run tests every night
+        - cron: "45 21 * * *"
+    workflow_dispatch: ~
+
+jobs:
+    nightly:
+        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            max-parallel: 1
+            matrix:
+                repository:
+                    - ibexa/oss
+                    - ibexa/content
+                    - ibexa/experience
+                    - ibexa/commerce
+                branch:
+                    - 3.3
+                    - master
+        steps:
+            - uses: octokit/request-action@v2.x
+              name: Trigger workflow
+              with:
+                  repository: ${{ matrix.repository }}
+                  workflow: "browser-tests.yml"
+                  ref: "!!str ${{ matrix.branch }}"
+                  route: POST /repos/{repository}/actions/workflows/{workflow}/dispatches
+              env:
+                  GITHUB_TOKEN: ${{ secrets.TRAVIS_GITHUB_TOKEN }}


### PR DESCRIPTION
Adding a new Github Actions job that triggers the browser tests defined in other repositories.

The goal is to have it run every day during the night (to protect us from all kinds of regression) or possibly on demand, when we want to check something.

We had something like for Travis and it proved to be very valuable.