### PR TITLE
[Composer] Added conflict with CaptchaBundle 2.2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,7 @@
         "ibexa/ci-scripts": "^0.1@dev"
     },
     "conflict": {
-        "gregwar/captcha-bundle": "2.1.6 || 2.1.7",
+        "gregwar/captcha-bundle": "2.2.0",
         "lexik/jwt-authentication-bundle": "2.12.0",
         "symfony/dependency-injection": "5.3.7"
     },


### PR DESCRIPTION
Follow-up to https://github.com/ibexa/oss/pull/33

As you might remember from the previous part of this saga, we need to prevent installation of the latest version of gregwar/CaptchaBundle.

The releases that were not working for us were 2.1.6 and 2.1.7, but these are no longer available: instead, a new tag 2.2.0 has been pushed. See https://github.com/Gregwar/CaptchaBundle/tags
