### PR TITLE
[Rebranding] Remove ibexa/compatibility-layer from default installation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
         "ibexa/solr": "^4.0.x-dev",
         "ibexa/standard-design": "^4.0.x-dev",
         "ibexa/user": "^4.0.x-dev",
-        "ibexa/compatibility-layer": "^4.0.x-dev",
         "symfony/asset": "^5.3.0",
         "symfony/cache": "^5.3.0",
         "symfony/console": "^5.3.0",


### PR DESCRIPTION
Related: https://github.com/ibexa/recipes/pull/81