### PR TITLE
IBX-2338: Added conflict for webpack-encore-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,8 @@
         "gregwar/captcha-bundle": "2.2.0",
         "lexik/jwt-authentication-bundle": "2.12.0",
         "symfony/dependency-injection": "5.3.7",
-        "symfony/framework-bundle": "5.3.14 || 5.4.3"
+        "symfony/framework-bundle": "5.3.14 || 5.4.3",
+        "symfony/webpack-encore-bundle": "1.14.0"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
JIRA ref: https://issues.ibexa.co/browse/IBX-2338

Added conflict for webpack-encore-bundle, as version 1.14 introduced bug, where calling render() function resets already included files.

Related symfony issue: https://github.com/symfony/webpack-encore-bundle/issues/166