### PR TITLE
[Composer] Allowed using symfony/flex v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "symfony/console": "^5.3.0",
         "symfony/dotenv": "^5.3.0",
         "symfony/expression-language": "^5.3.0",
-        "symfony/flex": "^1.11",
+        "symfony/flex": "^1.11 || ^2",
         "symfony/form": "^5.3.0",
         "symfony/framework-bundle": "^5.3.0",
         "symfony/monolog-bundle": "^3.6.0",


### PR DESCRIPTION
This brings the requirement inline with https://github.com/ibexa/website-skeleton/blob/3.3/composer.json#L12

Currently when installing on PHP 8 the following happens:
1) When website-skeleton is installed then symfony/flex v2 is installed
2) When the step `composer require ibexa/<edition>` is executed then the version is downgraded - because only v1 is allowed.

I've testes installation on both versions (symfony/flex v1 and symfony/flex v2) and it works correctly on both, our requirements should be the same for both packages.