### PR TITLE
[Composer] Added imagine/imagine conflict

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,6 +67,7 @@
     },
     "conflict": {
         "gregwar/captcha-bundle": "2.2.0",
+        "imagine/imagine": "1.3.0 || 1.3.1",
         "lexik/jwt-authentication-bundle": "2.12.0",
         "symfony/dependency-injection": "5.3.7",
         "symfony/framework-bundle": "5.3.14 || 5.4.3",


### PR DESCRIPTION
Our tests started failing with errors similar to `Failed to load resource: the server responded with a status of 502 (Bad Gateway)`

REST Tests:
https://app.travis-ci.com/github/ezsystems/ezplatform-rest/builds/247979930
```
1) EzSystems\EzPlatformRestBundle\Tests\Functional\BinaryContentTest::testGetImageVariation
Failed asserting that 502 matches expected 200.
/var/www/ezsystems/ezplatform-rest/tests/bundle/Functional/TestCase.php:216
/var/www/ezsystems/ezplatform-rest/tests/bundle/Functional/BinaryContentTest.php:101
phpvfscomposer:///var/www/ezsystems/ezplatform-rest/vendor/phpunit/phpunit/phpunit:97
```

Browser tests:
https://github.com/ibexa/commerce/actions/runs/1989433285
```
        │  	http://web/admin/page/block/preview/siteaccess/site - Failed to load resource: the server responded with a status of 502 (Bad Gateway)
```
```
    │  	http://web/product-catalog/testCategory/product - Failed to load resource: the server responded with a status of 502 (Bad Gateway)
```

Some logs from the Docker containers from the failed job (https://app.travis-ci.com/github/ezsystems/ezplatform-rest/builds/247971400):
```
web_1       | 2022-03-16T10:20:53.320977547Z 172.19.0.4 - - [16/Mar/2022:10:20:53 +0000] "POST /api/ezp/v2/user/sessions HTTP/1.1" 201 584 "-" "Symfony HttpClient/Curl" "-"

web_1       | 2022-03-16T10:20:53.504025837Z 172.19.0.4 - - [16/Mar/2022:10:20:53 +0000] "GET /api/ezp/v2/content/objects/52/versions/1 HTTP/1.1" 200 5112 "-" "Symfony HttpClient/Curl" "-"

web_1       | 2022-03-16T10:20:53.683592022Z 2022/03/16 10:20:53 [error] 9#9: *4 recv() failed (104: Connection reset by peer) while reading response header from upstream, client: 172.19.0.4, server: localhost, request: "GET /api/ezp/v2/content/binary/images/52-183-1/variations/medium HTTP/1.1", upstream: "fastcgi://172.19.0.4:9000", host: "web"

app_1       | 2022-03-16T10:20:53.688494227Z [16-Mar-2022 10:20:53] WARNING: [pool www] child 208 exited on signal 11 (SIGSEGV - core dumped) after 79.766833 seconds from start
```

Looks like only PHP 7.3 is affected, the issue did not occur on other PHP versions.

Imagine/imagine had a new release recently: https://github.com/php-imagine/Imagine/releases

The conflict was tested in https://github.com/ezsystems/ezplatform-rest/pull/92