### PR TITLE
[Composer] Added Doctrine conflicts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,6 +66,8 @@
         "ibexa/ci-scripts": "^0.1@dev"
     },
     "conflict": {
+        "doctrine/doctrine-bundle": "2.6.3",
+        "doctrine/persistence": "3.0.0",
         "gregwar/captcha-bundle": "2.2.0",
         "imagine/imagine": "1.3.0 || 1.3.1",
         "lexik/jwt-authentication-bundle": "2.12.0",


### PR DESCRIPTION
Installation fails with:
```
In ExtensionMetadataFactory.php line 104:

  Attempted to call an undefined method named "getCacheDriver" of class "Doct
  rine\Bundle\DoctrineBundle\Mapping\ClassMetadataFactory".
```

1) New Doctrine release allows to use doctrine/persistence 3.0.0 (https://github.com/doctrine/DoctrineBundle/pull/1510)
2) doctirne/persistence removes the `getCacheDriver` method (https://github.com/doctrine/persistence/blob/3.0.x/UPGRADE.md#bc-break-removed-support-for-doctrinecache)
3) This method is used by gedmo/doctrine-extensions (used in Content, Experience and Commerce editions of v4)

This is a short term fix to keep the project installing.

## Long term solution:
A) We need to wait until gedmo/doctrine-extensions releases a version supporting doctrine/persistence:^3.0 and then we can update.
B) Specify `doctrine/persistence:^2.0` as our dependency to block the installation of the higher major until the release of gedmo/doctrine-extensions happens