### PR TITLE
Bump flex to ^1.17 - old infrastructure shutting down

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "symfony/console": "^5.3.0",
         "symfony/dotenv": "^5.3.0",
         "symfony/expression-language": "^5.3.0",
-        "symfony/flex": "^1.11 || ^2",
+        "symfony/flex": "^1.17 || ^2",
         "symfony/form": "^5.3.0",
         "symfony/framework-bundle": "^5.3.0",
         "symfony/monolog-bundle": "^3.6.0",


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | -
| **Type**                                   | feature
| **Target Ibexa version** | `v3.*`
| **BC breaks**                          | no
| **Doc needed**                       | no

More information: https://symfony.com/blog/the-old-flex-infrastructure-is-shutting-down

#### Checklist:
- [x] Provided PR description.
- [ ] Tested the solution manually.
- [ ] Checked that target branch is set correctly.
- [ ] Asked for a review (ping `@ibexa/engineering`).
