### PR TITLE
[Composer] Pinned doctrine/persistence to ^2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,8 @@
         "platformsh/symfonyflex-bridge": "^2.4",
         "sensio/framework-extra-bundle": "^6.1.0",
         "twig/extra-bundle": "^3.1.1",
-        "doctrine/doctrine-bundle": "^2.4.2"
+        "doctrine/doctrine-bundle": "^2.4.2",
+        "doctrine/persistence": "^2.0"
     },
     "require-dev": {
         "ibexa/ci-scripts": "^0.2@dev"


### PR DESCRIPTION
This change is meant for 4.0 only - it will be removed when merging up to 4.1 and master.

Pining doctrine/persistence to ^2.0 allows us to keep using the deprecatated syntax for Doctrine entities (see: https://github.com/ezsystems/ezcommerce-shop/pull/423 )