### PR TITLE
[CI] Removed nightly build for 4.0 version

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,7 +19,6 @@ jobs:
                     - ibexa/commerce
                 branch:
                     - "3.3"
-                    - "4.0"
                     - "4.1"
                     - master
         steps:


### PR DESCRIPTION
4.0 is has reached the end of life phase (https://support.ibexa.co/Public/service-life)

We can remove this version from the nightly builds.