### PR TITLE
Remove symfony/thanks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,6 @@
         "symfony/security-bundle": "^5.3.0",
         "symfony/serializer-pack": "^1.0",
         "symfony/swiftmailer-bundle": "^3.5.1",
-        "symfony/thanks": "^1.2",
         "symfony/translation": "^5.3.0",
         "symfony/twig-bundle": "^5.3.0",
         "symfony/validator": "^5.3.0",


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | N/A
| **Type**                                   | improvement
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no
| **Doc needed**                       | no

This removes `symfony/thanks` package from require section for two reasons:

1) Since introduction of `allow-plugins` and since July 1st, Composer enforces that each plugin is listed in `allow-plugins`, and by default, `symfony/thanks` does not run any more, and is currently only a hinderance when installing, due to Composer asking if we want to execute it or not.

2) None of the Symfony packages depend on `symfony/thanks` any more: https://packagist.org/packages/symfony/thanks/dependents?order_by=name&requires=all&page=1

Similar PR on Sylius: https://github.com/Sylius/Sylius/pull/14106

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Checked that target branch is set correctly.
- [x] Asked for a review (ping `@ibexa/engineering`).
