### PR TITLE
[Browser tests] Disabled success notification for nightly builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,5 +29,6 @@ jobs:
                   workflow: "browser-tests.yml"
                   ref: "!!str ${{ matrix.branch }}"
                   route: POST /repos/{repository}/actions/workflows/{workflow}/dispatches
+                  inputs: '{ "send-success-notification": "false" }'
               env:
                   GITHUB_TOKEN: ${{ secrets.TRAVIS_GITHUB_TOKEN }}


### PR DESCRIPTION
Final touch for the series of PRs:
https://github.com/ibexa/gh-workflows/pull/21
https://github.com/ibexa/oss/pull/58
https://github.com/ibexa/content/pull/43
https://github.com/ibexa/experience/pull/55
https://github.com/ibexa/commerce/pull/109

This one actually disables success notifications for nightly builds