### PR TITLE
[Composer] Limit assets to 4.1.x series for 4.1 branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "ibexa/doctrine-schema": "~4.1.x-dev",
         "ibexa/system-info": "~4.1.x-dev",
         "ibexa/admin-ui": "~4.1.x-dev",
-        "ibexa/admin-ui-assets": "^4.0@beta",
+        "ibexa/admin-ui-assets": "~4.1.0@beta",
         "ibexa/content-forms": "~4.1.x-dev",
         "ibexa/core": "~4.1.x-dev",
         "ibexa/cron": "~4.1.x-dev",


### PR DESCRIPTION
To avoid current 4.1.x installation errors (https://github.com/ibexa/oss/actions/runs/2828526286):
```
 !!    Module build failed (from ./node_modules/postcss-loader/src/index.js):       
!!    Error: PostCSS plugin postcss-ckeditor5-theme-importer requires PostCSS 8.   
!!    Migration guide for end-users:                                               
!!    https://github.com/postcss/postcss/wiki/PostCSS-8-for-end-users              
!!        at Processor.normalize (/var/www/node_modules/postcss/lib/processor.js:  
!!    167:15)                                                                      
!!        at new Processor (/var/www/node_modules/postcss/lib/processor.js:56:25)  
!!        at postcss (/var/www/node_modules/postcss/lib/postcss.js:55:10)          
!!        at /var/www/node_modules/postcss-loader/src/index.js:140:12       
```

we need to pin the admin-ui-assets dependency to 4.1.x for 4.1.x series.