### PR TITLE
[Composer] Bumped ibexa/admin-ui-assets to ~4.2.2@alpha

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "ibexa/doctrine-schema": "~4.2.x-dev",
         "ibexa/system-info": "~4.2.x-dev",
         "ibexa/admin-ui": "~4.2.x-dev",
-        "ibexa/admin-ui-assets": "~4.2.0@alpha",
+        "ibexa/admin-ui-assets": "~4.2.2@alpha",
         "ibexa/content-forms": "~4.2.x-dev",
         "ibexa/core": "~4.2.x-dev",
         "ibexa/cron": "~4.2.x-dev",


### PR DESCRIPTION
Bumping requirements to use the latest ~4.2.2@alpha tag.

The issues reported in tests are fixed in 
- https://github.com/ibexa/admin-ui/pull/584
