### PR TITLE
[CI] Added nightly E2E tests running on 4.3

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -20,6 +20,7 @@ jobs:
                 branch:
                     - "3.3"
                     - "4.2"
+                    - "4.3"
                     - master
         steps:
             - uses: octokit/request-action@v2.x


### PR DESCRIPTION
This PR adds running nightly E2E tests on the new 4.3 version