### PR TITLE
[Composer] Added conflict with symfony/dependency-injection 5.4.17

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -70,7 +70,7 @@
         "gregwar/captcha-bundle": "2.2.0",
         "imagine/imagine": "1.3.0 || 1.3.1",
         "lexik/jwt-authentication-bundle": "2.12.0",
-        "symfony/dependency-injection": "5.3.7",
+        "symfony/dependency-injection": "5.3.7 || 5.4.17",
         "symfony/framework-bundle": "5.3.14 || 5.4.3",
         "symfony/expression-language": "5.4.7",
         "symfony/webpack-encore-bundle": "1.14.0"


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | -
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`+
| **BC breaks**                          | no
| **Doc needed**                       | no

Added conflict with symfony/dependency-injection v5.4.17. 

It seems that https://github.com/symfony/symfony/pull/48791 introduced bug (to be investigated) which cause

```
In StorageEngineFactory.php line 74:
                                                                                                            
  Invalid storage engine 'legacy'. Could not find any service tagged with ibexa.storage with alias legacy.  
```

error during container compilation. Ref. https://github.com/ibexa/commerce/actions/runs/3794579011/jobs/6453253203 
                                                                                         

#### Checklist:
- [X] Provided PR description.
- [X] Tested the solution manually.
- [X] Checked that target branch is set correctly.
- [X] Asked for a review (ping `@ibexa/engineering`).
