### PR TITLE
[Composer] Bumped admin-ui-assets version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "ibexa/doctrine-schema": "~4.4.x-dev",
         "ibexa/system-info": "~4.4.x-dev",
         "ibexa/admin-ui": "~4.4.x-dev",
-        "ibexa/admin-ui-assets": "~4.4.0@alpha",
+        "ibexa/admin-ui-assets": "~4.4.1@alpha",
         "ibexa/content-forms": "~4.4.x-dev",
         "ibexa/core": "~4.4.x-dev",
         "ibexa/cron": "~4.4.x-dev",


### PR DESCRIPTION
This bump is required because we use `prefer-stable: true` in the skeleton - and Composer picks 4.4.0 to install without this change.