### PR TITLE
[CI] Renamed PIM repository

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,7 +24,7 @@ jobs:
                 include:
                     - repository: ibexa/headless
                       branch: master
-                    - repository: ibexa/example-remote-product-catalog
+                    - repository: ibexa/example-in-memory-product-catalog
                       branch: main
                 exclude:
                     - repository: ibexa/content


### PR DESCRIPTION
https://github.com/ibexa/example-remote-product-catalog has been renamed to https://github.com/ibexa/example-in-memory-product-catalog