### PR TITLE
[CI] Adjusted test matrix to CKE40 Node requirement

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
     regression-oss-setup1:
-        name: "PHP 7.4/Node 14/PostgreSQL/Varnish/Redis"
+        name: "PHP 7.4/Node 18/PostgreSQL/Varnish/Redis"
         uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
         with:
             project-edition: "oss"
@@ -30,7 +30,7 @@ jobs:
             setup: "doc/docker/base-dev.yml:doc/docker/db-postgresql.yml:doc/docker/varnish.yml:doc/docker/redis.yml:doc/docker/selenium.yml"
             send-success-notification: ${{ github.event.inputs.send-success-notification != 'false' }}
             multirepository: true
-            php-image: "ghcr.io/ibexa/docker/php:7.4-node14"
+            php-image: "ghcr.io/ibexa/docker/php:7.4-node18"
             job-count: 2
             timeout: 60
         secrets:
@@ -39,7 +39,7 @@ jobs:
             AUTOMATION_CLIENT_INSTALLATION: ${{ secrets.AUTOMATION_CLIENT_INSTALLATION }}
             AUTOMATION_CLIENT_SECRET: ${{ secrets.AUTOMATION_CLIENT_SECRET }}
     regression-oss-setup2:
-        name: "PHP 8.0/Node 16/MySQL/Compatibility layer"
+        name: "PHP 8.0/Node 18/MySQL/Compatibility layer"
         uses: ibexa/gh-workflows/.github/workflows/browser-tests.yml@main
         with:
             project-edition: "oss"
@@ -52,7 +52,7 @@ jobs:
             use-compatibility-layer: true
             job-count: 2
             timeout: 60
-            php-image: "ghcr.io/ibexa/docker/php:8.0-node16"
+            php-image: "ghcr.io/ibexa/docker/php:8.0-node18"
         secrets:
             SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
             AUTOMATION_CLIENT_ID: ${{ secrets.AUTOMATION_CLIENT_ID }}
@@ -69,7 +69,6 @@ jobs:
             send-success-notification: ${{ github.event.inputs.send-success-notification != 'false' }}
             job-count: 2
             timeout: 60
-            php-image: "ghcr.io/ibexa/docker/php:8.1-node18"
         secrets:
             SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
             AUTOMATION_CLIENT_ID: ${{ secrets.AUTOMATION_CLIENT_ID }}

--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -69,6 +69,7 @@ jobs:
             send-success-notification: ${{ github.event.inputs.send-success-notification != 'false' }}
             job-count: 2
             timeout: 60
+            php-image: "ghcr.io/ibexa/docker/php:8.1-node18"
         secrets:
             SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
             AUTOMATION_CLIENT_ID: ${{ secrets.AUTOMATION_CLIENT_ID }}


### PR DESCRIPTION
Needed by:
- https://github.com/ibexa/admin-ui-assets/pull/19.

Related:
- https://github.com/ibexa/fieldtype-richtext/pull/136
- https://github.com/ibexa/recipes-dev/pull/97.

Rationale: CKE40 requires at least Node 18.
