### PR TITLE
[Composer] Added conflict with lexik/jwt-authentication-bundle  2.20.0 and 2.20.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,7 @@
         "doctrine/persistence": "3.0.0",
         "gregwar/captcha-bundle": "2.2.0",
         "imagine/imagine": "1.3.0 || 1.3.1",
-        "lexik/jwt-authentication-bundle": "2.12.0 || 2.18.0",
+        "lexik/jwt-authentication-bundle": "2.12.0 || 2.18.0 || 2.20.0 || 2.20.1",
         "symfony/dependency-injection": "5.3.7 || 5.4.17",
         "symfony/framework-bundle": "5.3.14 || 5.4.3",
         "symfony/expression-language": "5.4.7",


### PR DESCRIPTION
The latest releases (https://github.com/lexik/LexikJWTAuthenticationBundle/releases) are not compatible with lower PHP versions:
- 2.20.0: not compatibile with PHP 7.3 and 7.4
- 2.20.1: not compatibile with PHP 7.3

These issues are fixed already:
PHP 7.4: https://github.com/lexik/LexikJWTAuthenticationBundle/pull/1172
PHP 7.3: https://github.com/lexik/LexikJWTAuthenticationBundle/pull/1174

and once the PHP 7.3 issue is released everything will be passing - we just need to wait until it's released.

And it's better to wait with green CI than with a failing one 😄 

This is needed for Ibexa 3.3, which still supports PHP 7.3 - the lowest supported PHP version for v4 is 7.4 which is already supported by 2.20.1