### PR TITLE
[Composer] Added conflict with lexik/jwt-authentication-bundle  2.20.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,7 @@
         "doctrine/persistence": "3.0.0",
         "gregwar/captcha-bundle": "2.2.0",
         "imagine/imagine": "1.3.0 || 1.3.1",
-        "lexik/jwt-authentication-bundle": "2.12.0 || 2.18.0 || 2.20.0 || 2.20.1",
+        "lexik/jwt-authentication-bundle": "2.12.0 || 2.18.0 || 2.20.0 || 2.20.1 || 2.20.2",
         "symfony/dependency-injection": "5.3.7 || 5.4.17",
         "symfony/framework-bundle": "5.3.14 || 5.4.3",
         "symfony/expression-language": "5.4.7",


### PR DESCRIPTION
v2.20.2 is still not compatible with PHP 7.3: https://github.com/lexik/LexikJWTAuthenticationBundle/releases/tag/v2.20.2

There's an open PR for it already, hopefully the next release is fully compliant.