### PR TITLE
[Composer] Added conflict with friends-of-behat/mink-browserkit-driver:v1.6.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,8 @@
         "symfony/framework-bundle": "5.3.14 || 5.4.3",
         "symfony/expression-language": "5.4.7",
         "symfony/webpack-encore-bundle": "1.14.0",
-        "friends-of-behat/mink-browserkit-driver": "1.6.2"
+        "friends-of-behat/mink-browserkit-driver": "1.6.2",
+        "behat/mink-selenium2-driver": "1.7.0"
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -73,7 +73,8 @@
         "symfony/dependency-injection": "5.3.7 || 5.4.17",
         "symfony/framework-bundle": "5.3.14 || 5.4.3",
         "symfony/expression-language": "5.4.7",
-        "symfony/webpack-encore-bundle": "1.14.0"
+        "symfony/webpack-encore-bundle": "1.14.0",
+        "friends-of-behat/mink-browserkit-driver": "1.6.2"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
CI failure:
```
 PHP Fatal error:  Declaration of Behat\Mink\Driver\GoutteDriver::getClient() must be compatible with Behat\Mink\Driver\BrowserKitDriver::getClient(): Symfony\Component\BrowserKit\AbstractBrowser in /var/www/vendor/behat/mink-goutte-driver/src/GoutteDriver.php on line 54
```

https://github.com/FriendsOfBehat/MinkBrowserKitDriver/releases/tag/v1.6.2

The real fix is to get rid of the GoutteDriver, but until I prepare it it's better to have green CI