### PR TITLE
Remove hautelook/templated-uri-bundle fork

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,6 @@
         "symfony/webpack-encore-bundle": "^1.8",
         "symfony/yaml": "^5.3.0",
         "friendsofsymfony/jsrouting-bundle": "^2.7.0",
-        "ibexa/templated-uri-bundle": "^3.3.1",
         "knplabs/knp-menu-bundle": "^3.1",
         "lexik/jwt-authentication-bundle": "^2.10.5",
         "monolog/monolog": "^2.2",


### PR DESCRIPTION
| :ticket: Issue | IBX-8135 |
|----------------|-----------|

#### Related PRs: 
https://github.com/ibexa/rest/pull/88
https://github.com/ibexa/dashboard/pull/124
https://github.com/ibexa/system-info/pull/51

#### Description:
The hautelook/templated-uri-bundle fork is not needed anymore and can be removed from dependencies.

#### For QA:
Sanities only.

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
