### PR TITLE
[Behat] Nightly example-in-memory-product-catalog job removal

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,8 +26,6 @@ jobs:
                       branch: "3.3"
                     - repository: ibexa/example-in-memory-product-catalog
                       branch: "4.6"
-                    - repository: ibexa/example-in-memory-product-catalog
-                      branch: main
                 exclude:
                     - repository: ibexa/headless
                       branch: "3.3"


### PR DESCRIPTION
| :ticket: Issue | IBX-XXXXX |
|----------------|-----------|

#### Description:
This PR removes example-in-memory-product-catalog bundle from Nightly build on master. This bundle is not upgraded to SF6, so it will produces errors during config setup.

