### PR TITLE
[Behat] Nightly browser tests job removal for example-in-memory-produ…

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,8 +24,6 @@ jobs:
                 include:
                     - repository: ibexa/content
                       branch: "3.3"
-                    - repository: ibexa/example-in-memory-product-catalog
-                      branch: "4.6"
                 exclude:
                     - repository: ibexa/headless
                       branch: "3.3"


### PR DESCRIPTION
…ct-catalog (4.6)

| :ticket: Issue | IBX-XXXXX |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
This PR removes example-in-memory-product-catalog bundle from Nightly build on 4.6.

Follow-up to https://github.com/ibexa/example-in-memory-product-catalog/pull/11.

Example failure: https://github.com/ibexa/oss/actions/runs/13663566099/job/38199966945

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
