### PR TITLE
IBX-9942: Removed platformsh/symfonyflex-bridge dependency from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,6 @@
         "lexik/jwt-authentication-bundle": "^2.10.5",
         "monolog/monolog": "^3.8",
         "overblog/graphiql-bundle": "^1.0",
-        "platformsh/symfonyflex-bridge": "^2.4",
         "twig/extra-bundle": "^3.1.1",
         "doctrine/doctrine-bundle": "^2.11.0"
     },


### PR DESCRIPTION
| :ticket: Issue | IBX-9942 |
|----------------|-----------|

#### Related PRs: 
https://github.com/ibexa/post-install/pull/92


#### Description:
Remove platformsh/symfonyflex-bridge dependency from composer.json
