### PR TITLE
IBX-8471: [Composer] Dropped conflict with mink-browserkit-driver v1.6.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,6 @@
         "symfony/framework-bundle": "5.3.14 || 5.4.3",
         "symfony/expression-language": "5.4.7",
         "symfony/webpack-encore-bundle": "1.14.0",
-        "friends-of-behat/mink-browserkit-driver": "1.6.2",
         "behat/mink-selenium2-driver": "1.7.0"
     },
     "extra": {


### PR DESCRIPTION
> [!CAUTION]
> - [x] Drop TMP commit before merging

| :ticket: Issue | IBX-8471 |
|----------------|-----------|

#### Related PRs: 
- https://github.com/ibexa/oss/pull/136
- https://github.com/ibexa/behat/pull/130


#### Description:

Reverting conflict added via #136 for 3.3.

Seems GoutteDriver was dropped via https://github.com/ibexa/behat/pull/130, so maybe it's enough to remove that conflict now?
We need v1.6.2 as this is the only tag supporting Symfony 7.
