### PR TITLE
[Nightly browser tests] Set cron to 6:00 AM

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,8 +1,8 @@
 name: Nightly browser tests
 on:
     schedule:
-        # Run tests every night
-        - cron: "45 21 * * *"
+        # Run tests every morning
+        - cron: "0 6 * * *"
     workflow_dispatch: ~
 
 jobs:


### PR DESCRIPTION
| :ticket: Issue | IBX-XXXXX |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Set cron to 6:00 AM for nightly browser tests.

The reason for the change: Reducing time during release day needed for the process. Aim is to not repeat regression tests ad hoc. This change takes into account possible 3rd party impact during the night.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
