### PR TITLE
IBX-11720: [GHA][Create Tag] Fixed PHP version used when creating ibexa/oss 4.6 tags

### DIFF
--- a/.github/workflows/auto_tag.yml
+++ b/.github/workflows/auto_tag.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Setup PHP Action
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.1
+          php-version: 8.3
           coverage: none
           extensions: pdo_sqlite, gd
           tools: cs2pr


### PR DESCRIPTION
| :ticket: Issue | IBX-11720 |
|----------------|-----------|

#### Description:
Updated the `Create Tag` workflow in `ibexa/oss` `4.6` to use PHP `8.3` instead of `8.1` when creating tags.

All other workflows for the other editions use already PHP 8.3.

#### For QA:

Not needed. Dry-run `Create Tag` run for this branch: https://github.com/ibexa/oss/actions/runs/25865066671/job/76004878037.

#### Documentation:
Not needed.
