### PR TITLE
IBX-11778: Updated deprecated GitHub Actions in auto_tag and nightly workflows

### DIFF
--- a/.github/workflows/auto_tag.yml
+++ b/.github/workflows/auto_tag.yml
@@ -20,6 +20,8 @@ on:
 jobs:
   preparation:
     runs-on: ubuntu-26.04
+    # This should allow parallel runs in a chain, e.g. OSS->Headless->Experience->Commerce
+    timeout-minutes: 30
 
     steps:
       - name: Check for admin-ui-assets package

--- a/.github/workflows/auto_tag.yml
+++ b/.github/workflows/auto_tag.yml
@@ -20,140 +20,31 @@ on:
 jobs:
   preparation:
     runs-on: ubuntu-26.04
-    # This should allow parallel runs in a chain, e.g. OSS->Headless->Experience->Commerce
-    # whilst allowing Satis to process
-    timeout-minutes: 30
 
     steps:
-      - name: Generate token
-        id: generate_token
-        uses: actions/create-github-app-token@v3
+      - name: Check for admin-ui-assets package
+        uses: ibexa/gh-workflows/actions/check-composer-package@main
         with:
-          client-id: ${{ secrets.AUTOMATION_CLIENT_ID }}
-          private-key: ${{ secrets.AUTOMATION_CLIENT_SECRET }}
-          owner: ${{ github.repository_owner }}
-
-      - name: Check for admin-ui-assets tag
-        shell: bash
-        run: gh api "/repos/ibexa/admin-ui-assets/contents/package.json?ref=v${{ inputs.version }}" >/dev/null
-        env:
-          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+          package: ibexa/admin-ui-assets
+          version: v${{ inputs.version }}
 
   action:
     needs: preparation
     runs-on: ubuntu-26.04
-    
+
     steps:
-      - name: Install sponge
-        run: |
-          sudo apt-get install -y moreutils
-
-      - name: Setup PHP Action
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: 8.3
-          coverage: none
-          extensions: pdo_sqlite, gd
-
-      - name: Generate token
-        id: generate_token
-        uses: actions/create-github-app-token@v3
-        with:
-          client-id: ${{ secrets.AUTOMATION_CLIENT_ID }}
-          private-key: ${{ secrets.AUTOMATION_CLIENT_SECRET }}
-          owner: ${{ github.repository_owner }}
-
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
 
-      - name: Get release information
-        id: release
-        shell: bash
-        run: |
-          response=$(gh api "/repos/ibexa/release-maker/contents/releases/${{ inputs.version }}/release.json")
-          {
-            echo 'data<<EOF'
-            echo "$response"
-            echo EOF
-          } >> "$GITHUB_OUTPUT"
-        env:
-          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
-
-      # The effect of this jq command is to take a JSON array of objects,
-      # transform each object into a new object using its packageName and targetVersion properties,
-      # and return the result as a single JSON object.
-      # The sponge command is used to pipe the output of jq back into the same file, effectively replacing its contents with the updated JSON data.
-      - name: Process release information
-        run: |
-          cat > input.json <<'EOF'
-          ${{ steps.release.outputs.data }}
-          EOF
-          jq -r '.["content"]' input.json | base64 --decode | jq -c . > release.json
-          jq -s '[ .[][] | { (.packageName): (.targetVersion) } ] | add' release.json | sponge release.json
-
-      - name: Set minimum stability
-        run: |
-          VERSION=$( echo ${{ inputs.version }} | cut -d '-' -f 2 )
-          SET_STABILITY="composer config minimum-stability"
-          $SET_STABILITY --unset
-          composer config prefer-stable --unset
-          case $VERSION in
-            alpha*|beta*|rc*) composer config prefer-stable true ;;&
-            alpha*) $SET_STABILITY alpha ;;
-            beta*) $SET_STABILITY beta ;;
-            rc*) $SET_STABILITY rc ;;
-          esac;
-
-      - name: Patch parent version for OSS
-        run: jq '.require["ibexa/admin-ui-assets"] |= "${{ inputs.version }}"' composer.json | sponge composer.json
-
-      # The effect of this jq command is to modify the require property of the input JSON object by using values from the $release object,
-      # if they exist, to update the values of the keys in the require object.
-      - name: Patch composer require versions
-        run: |
-          jq --slurpfile release <(cat release.json) '
-            .require |= (
-              to_entries | 
-              map({
-                key: .key,
-                value: (if ($release[0][.key]) then $release[0][.key] else .value end)
-              }) | from_entries
-            )
-          ' composer.json > composer.tmp
-          mv composer.tmp composer.json
-
-      - name: Reformat composer.json
-        run: cat composer.json | unexpand -t2 | expand -t4 | sponge composer.json
-
-      - name: Preview composer.json
-        run: cat composer.json
-
-      - name: Add composer keys for private packagist
-        run: |
-          composer config http-basic.updates.ibexa.co $SATIS_NETWORK_KEY $SATIS_NETWORK_TOKEN
-          composer config github-oauth.github.com $APP_GITHUB_TOKEN
-        env:
-          SATIS_NETWORK_KEY: ${{ secrets.SATIS_NETWORK_KEY }}
-          SATIS_NETWORK_TOKEN: ${{ secrets.SATIS_NETWORK_TOKEN }}
-          APP_GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
-
-      - name: Composer update
-        run: |
-          composer update --no-scripts --no-plugins --no-install
-          composer validate
-
-      - name: Commit, tag and push
-        if: inputs.real_op
-        env:
-          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
-          GIT_PUSH_ARGS: ${{ inputs.git_push_args }}
-          VERSION: ${{ inputs.version }}
-        run: |
-          gh auth setup-git
-          git config --local user.name "github-actions[bot]"
-          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add composer.*
-          git commit -m "[composer] Set dependencies for ${VERSION} release + .lock"
-          git tag "v${VERSION}"
-          git push origin "v${VERSION}" ${GIT_PUSH_ARGS}
+      - name: Set dependency versions, commit, tag and push
+        uses: ibexa/gh-workflows/actions/create-metapackage-tag@main
+        with:
+          version: ${{ inputs.version }}
+          pin-packages: ibexa/admin-ui-assets
+          real-op: ${{ inputs.real_op }}
+          git-push-args: ${{ inputs.git_push_args }}
+          gh-client-id: ${{ secrets.AUTOMATION_CLIENT_ID }}
+          gh-client-secret: ${{ secrets.AUTOMATION_CLIENT_SECRET }}
+          satis-network-key: ${{ secrets.SATIS_NETWORK_KEY }}
+          satis-network-token: ${{ secrets.SATIS_NETWORK_TOKEN }}

--- a/.github/workflows/auto_tag.yml
+++ b/.github/workflows/auto_tag.yml
@@ -19,69 +19,29 @@ on:
 
 jobs:
   preparation:
-    runs-on: ubuntu-latest
-    # This should allow parallel runs in a chain, e.g. OSS->Content->Experience->Commerce
+    runs-on: ubuntu-26.04
+    # This should allow parallel runs in a chain, e.g. OSS->Headless->Experience->Commerce
     # whilst allowing Satis to process
     timeout-minutes: 30
 
     steps:
       - name: Generate token
         id: generate_token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.AUTOMATION_CLIENT_ID }}
+          client-id: ${{ secrets.AUTOMATION_CLIENT_ID }}
           private-key: ${{ secrets.AUTOMATION_CLIENT_SECRET }}
           owner: ${{ github.repository_owner }}
 
       - name: Check for admin-ui-assets tag
-        uses: octokit/request-action@v2.x
-        with:
-          owner: ibexa
-          repo: admin-ui-assets
-          route: /repos/{owner}/{repo}/contents/package.json?ref=v${{ inputs.version }}
+        shell: bash
+        run: gh api "/repos/ibexa/admin-ui-assets/contents/package.json?ref=v${{ inputs.version }}" >/dev/null
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
 
-      # The jq command would return a zero exit status if it was able to filter the input JSON data and
-      # produce at least one matching object in the array, and a non-zero exit status if no matching object was found.
-      # This particular JQ filter expression:
-      # .packages."${{ env.PARENT }}"[]: accesses an array of objects in the packages object, with the key specified by the environment variable PARENT.
-      # select(.version == "${{ env.V_VERSION }}"): filters the array to only include objects where the version property is equal to the value of the environment variable V_VERSION.
-
-      # No need to validate for oss version in satis
-      - name: Validate satis for content version
-        if: github.event.repository.name == 'experience'
-        env:
-          SATIS_NETWORK_KEY: ${{ secrets.SATIS_NETWORK_KEY }}
-          SATIS_NETWORK_TOKEN: ${{ secrets.SATIS_NETWORK_TOKEN }}
-          PARENT: ibexa/content
-          V_VERSION: v${{ inputs.version }}
-        run: |
-          for EXPONENTIAL_BACKOFF in {1..10}; do
-          curl https://updates.ibexa.co/p2/${PARENT}.json -s -u $SATIS_NETWORK_KEY:$SATIS_NETWORK_TOKEN | jq -e '.packages."${{ env.PARENT }}"[] | select(.version == "${{ env.V_VERSION }}")' && break;
-            DELAY=$((2**$EXPONENTIAL_BACKOFF))
-            echo "${PARENT}:${V_VERSION} not yet available, sleeping for $DELAY seconds"
-            sleep $DELAY
-          done
-
-      - name: Validate satis for experience version
-        if: github.event.repository.name == 'commerce'
-        env:
-          SATIS_NETWORK_KEY: ${{ secrets.SATIS_NETWORK_KEY }}
-          SATIS_NETWORK_TOKEN: ${{ secrets.SATIS_NETWORK_TOKEN }}
-          PARENT: ibexa/experience
-          V_VERSION: v${{ inputs.version }}
-        run: |
-          for EXPONENTIAL_BACKOFF in {1..10}; do
-          curl https://updates.ibexa.co/p2/${PARENT}.json -s -u $SATIS_NETWORK_KEY:$SATIS_NETWORK_TOKEN | jq -e '.packages."${{ env.PARENT }}"[] | select(.version == "${{ env.V_VERSION }}")' && break;
-            DELAY=$((2**$EXPONENTIAL_BACKOFF))
-            echo "${PARENT}:${V_VERSION} not yet available, sleeping for $DELAY seconds"
-            sleep $DELAY
-          done
-  
   action:
     needs: preparation
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-26.04
     
     steps:
       - name: Install sponge
@@ -94,27 +54,29 @@ jobs:
           php-version: 8.3
           coverage: none
           extensions: pdo_sqlite, gd
-          tools: cs2pr
 
       - name: Generate token
         id: generate_token
-        uses: tibdex/github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
-          app_id: ${{ secrets.AUTOMATION_CLIENT_ID }}
-          installation_id: ${{ secrets.AUTOMATION_CLIENT_INSTALLATION }}
-          private_key: ${{ secrets.AUTOMATION_CLIENT_SECRET }}
+          client-id: ${{ secrets.AUTOMATION_CLIENT_ID }}
+          private-key: ${{ secrets.AUTOMATION_CLIENT_SECRET }}
+          owner: ${{ github.repository_owner }}
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
 
       - name: Get release information
-        uses: octokit/request-action@v2.x
         id: release
-        with:
-          owner: ibexa
-          repo: release-maker
-          route: /repos/{owner}/{repo}/contents/releases/${{ inputs.version }}/release.json
+        shell: bash
+        run: |
+          response=$(gh api "/repos/ibexa/release-maker/contents/releases/${{ inputs.version }}/release.json")
+          {
+            echo 'data<<EOF'
+            echo "$response"
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
 
@@ -144,17 +106,7 @@ jobs:
           esac;
 
       - name: Patch parent version for OSS
-        if: github.event.repository.name == 'oss'
         run: jq '.require["ibexa/admin-ui-assets"] |= "${{ inputs.version }}"' composer.json | sponge composer.json
-      - name: Patch parent version for Content
-        if: github.event.repository.name == 'content'
-        run: jq '.require["ibexa/oss"] |= "${{ inputs.version }}"' composer.json | sponge composer.json
-      - name: Patch parent version for Experience
-        if: github.event.repository.name == 'experience'
-        run: jq '.require["ibexa/content"] |= "${{ inputs.version }}"' composer.json | sponge composer.json
-      - name: Patch parent version for Commerce
-        if: github.event.repository.name == 'commerce'
-        run: jq '.require["ibexa/experience"] |= "${{ inputs.version }}"' composer.json | sponge composer.json
 
       # The effect of this jq command is to modify the require property of the input JSON object by using values from the $release object,
       # if they exist, to update the values of the keys in the require object.

--- a/.github/workflows/auto_tag.yml
+++ b/.github/workflows/auto_tag.yml
@@ -146,13 +146,14 @@ jobs:
       - name: Commit, tag and push
         if: inputs.real_op
         env:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
           GIT_PUSH_ARGS: ${{ inputs.git_push_args }}
-          ROBOT_TOKEN: ${{ secrets.EZROBOT_PAT }}
+          VERSION: ${{ inputs.version }}
         run: |
-          git config --local user.email "681611+ezrobot@users.noreply.github.com"
-          git config --local user.name "ezrobot"
-          git remote set-url origin https://x-access-token:${{ env.ROBOT_TOKEN }}@github.com/${{ github.repository }}
+          gh auth setup-git
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add composer.*
-          git commit -m "[composer] Set dependencies for ${{ inputs.version }} release + .lock"
-          git tag "v${{ inputs.version }}"
-          git push origin "v${{ inputs.version }}" ${GIT_PUSH_ARGS}
+          git commit -m "[composer] Set dependencies for ${VERSION} release + .lock"
+          git tag "v${VERSION}"
+          git push origin "v${VERSION}" ${GIT_PUSH_ARGS}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
     nightly:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-26.04
         strategy:
             fail-fast: false
             max-parallel: 1
@@ -25,16 +25,14 @@ jobs:
             - uses: actions/create-github-app-token@v3
               id: generate_token
               with:
-                  app-id: ${{ secrets.AUTOMATION_CLIENT_ID }}
+                  client-id: ${{ secrets.AUTOMATION_CLIENT_ID }}
                   private-key: ${{ secrets.AUTOMATION_CLIENT_SECRET }}
                   owner: ${{ github.repository_owner }}
-            - uses: octokit/request-action@v2.x
-              name: Trigger workflow
-              with:
-                  repository: ${{ matrix.repository }}
-                  workflow: "browser-tests.yml"
-                  ref: "!!str ${{ matrix.branch }}"
-                  route: POST /repos/{repository}/actions/workflows/{workflow}/dispatches
-                  inputs: '{ "send-success-notification": "false" }'
+            - name: Trigger workflow
+              shell: bash
+              run: |
+                  gh api --method POST "/repos/${{ matrix.repository }}/actions/workflows/browser-tests.yml/dispatches" \
+                    -f ref="${{ matrix.branch }}" \
+                    -f "inputs[send-success-notification]=false"
               env:
                   GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
> [!CAUTION]
> - [x] Drop TMP commits before merging

| :ticket: Issue | IBX-11778 |
|----------------|-----------|

#### Related PRs:
- https://github.com/ibexa/gh-workflows/pull/103
- https://github.com/ibexa/gh-workflows/pull/105
- https://github.com/ibexa/commerce/pull/1891
- https://github.com/ibexa/experience/pull/604
- https://github.com/ibexa/headless/pull/286

#### Description:

Rewrote `auto_tag.yml` (Create Tag), 206 → 50 lines; for more details see ibexa/gh-workflows#105.

Specific to oss:

- The assets check runs against Packagist anonymously — the only edition using the action's default repository.
- `nightly.yml`: the `octokit/request-action` dispatch is now `gh api --method POST`, which also drops the `!!str` ref workaround, and `create-github-app-token` v3 receives `client-id` instead of the deprecated `app-id`.


#### For QA:

The shared actions are tested in ibexa/gh-workflows#105 — see its For QA.

Test status:

- [x] :green_circle: Dry run at 4.6.31 (`real_op: false`) from this branch, exercising the ibexa/gh-workflows#105 actions via the `[TMP]` refs [Create Tag run 31009047336](https://github.com/ibexa/oss/actions/runs/31009047336) — preparation checked `ibexa/admin-ui-assets` on Packagist anonymously, `ibexa/admin-ui-assets` pinned to 4.6.31, remaining requirements set from the release definition, `composer.lock` resolved, push step skipped, both jobs on `ubuntu-26.04`
- [x] :green_circle: Negative dry run at bogus version 9.9.9-test1 [Create Tag run 31010161799](https://github.com/ibexa/oss/actions/runs/31010161799) — preparation failed immediately with `::error::ibexa/admin-ui-assets:v9.9.9-test1 is not available in https://repo.packagist.org` and the `action` job was skipped
- [x] :green_circle: Nightly browser tests full-matrix dispatch from this branch [Nightly run 31016569268](https://github.com/ibexa/oss/actions/runs/31016569268) — all 12 `gh api --method POST` dispatches succeeded and a Browser Tests run appeared in every target (oss/headless/experience/commerce × 4.6/5.0/6.0) with `send-success-notification: false`. Also proves the dispatch idiom the four skeleton PRs rely on


#### Documentation:

No documentation required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

