### PR TITLE
IBX-12091: Added translations package dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "ibexa/search": "~6.0.x-dev",
         "ibexa/solr": "~6.0.x-dev",
         "ibexa/standard-design": "~6.0.x-dev",
+        "ibexa/translations": "~6.0.x-dev",
         "ibexa/twig-components": "~6.0.x-dev",
         "ibexa/user": "~6.0.x-dev",
         "symfony/asset": "^7.4",


### PR DESCRIPTION
| :ticket: Issue | IBX-12091 |
|----------------|-----------|

#### Related PRs:

- https://github.com/ibexa/translations/pull/3
- https://github.com/ibexa/admin-ui/pull/1993
- https://github.com/ibexa/recipes-dev/pull/255

#### Description:

Added `ibexa/translations` to the OSS metapackage. This makes the package available in all Ibexa editions that depend on `ibexa/oss`.

This PR stays in draft until `ibexa/translations` is available through the Composer repository used by Ibexa projects.

#### For QA:

No manual QA is required.

#### Documentation:

No documentation changes are required.
